### PR TITLE
fix: adjust permission name to "artifact:global:share:put"

### DIFF
--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -397,8 +397,8 @@ define(function(require, exports) {
 
     var isPermittedGlobalShareCohort = function() {
         // special * permission (intended for admins) that allows the
-        // user to share any cohort with a "global reader role":
-        return isPermitted('cohortdefinition:global:share:put');
+        // user to share any artifact with a "global reader role":
+        return isPermitted('artifact:global:share:put');
     }
 
     var isPermittedUpdateCohort = function(id) {


### PR DESCRIPTION
Fix: adjust permission name to "artifact:global:share:put" to better reflect its real purpose