### PR TITLE
Fix: better name for isPermittedGlobalShareArtifact 

### DIFF
--- a/js/pages/cohort-definitions/cohort-definition-manager.js
+++ b/js/pages/cohort-definitions/cohort-definition-manager.js
@@ -203,7 +203,7 @@ define(['jquery', 'knockout', 'text!./cohort-definition-manager.html',
 			if (config.enablePermissionManagement) {
 				this.userCanShare = ko.observable(
 						!config.limitedPermissionManagement ||
-						authApi.isPermittedGlobalShareCohort());
+						authApi.isPermittedGlobalShareArtifact());
 			} else {
 				this.userCanShare = ko.observable(false);
 			}

--- a/js/pages/concept-sets/conceptset-manager.js
+++ b/js/pages/concept-sets/conceptset-manager.js
@@ -179,7 +179,7 @@ define([
 			if (config.enablePermissionManagement) {
 				this.userCanShare = ko.observable(
 						!config.limitedPermissionManagement ||
-						authApi.isPermittedGlobalShareCohort());
+						authApi.isPermittedGlobalShareArtifact());
 			} else {
 				this.userCanShare = ko.observable(false);
 			}

--- a/js/services/AuthAPI.js
+++ b/js/services/AuthAPI.js
@@ -395,7 +395,7 @@ define(function(require, exports) {
         return isPermitted('cohortdefinition:' + id + ':copy:get');
     }
 
-    var isPermittedGlobalShareCohort = function() {
+    var isPermittedGlobalShareArtifact = function() {
         // special * permission (intended for admins) that allows the
         // user to share any artifact with a "global reader role":
         return isPermitted('artifact:global:share:put');
@@ -592,7 +592,7 @@ define(function(require, exports) {
         isPermittedReadCohort: isPermittedReadCohort,
         isPermittedCreateCohort: isPermittedCreateCohort,
         isPermittedCopyCohort: isPermittedCopyCohort,
-        isPermittedGlobalShareCohort: isPermittedGlobalShareCohort,
+        isPermittedGlobalShareArtifact: isPermittedGlobalShareArtifact,
         isPermittedUpdateCohort: isPermittedUpdateCohort,
         isPermittedDeleteCohort: isPermittedDeleteCohort,
         isPermittedGenerateCohort: isPermittedGenerateCohort,


### PR DESCRIPTION
Fixes the following issue:
- https://github.com/OHDSI/Atlas/pull/2929#discussion_r1603482538 

⚠️ after more review, I decided to NOT include https://github.com/uc-cdis/Atlas/pull/47/commits/b8fa9399de36fa5a6b697ee922d6693ba9943dbf  (the `isOwner()` change) because this will require changes in WebAPI which are related to "team projects", so that would delay this PR from merging upstream.
